### PR TITLE
Add output_path argument to TB2J_merge.py script

### DIFF
--- a/scripts/TB2J_merge.py
+++ b/scripts/TB2J_merge.py
@@ -24,8 +24,13 @@ def main():
         help=
         'The type of calculations, either structure of spin, meaning that the three calculations are done by rotating the structure/spin. '
     )
+    parser.add_argument(
+        "--output_path",
+        help="The path of the output directory, default is TB2J_results",
+        type=str,
+        default="TB2J_results")
     args = parser.parse_args()
-    merge(*(args.directories), args.type.strip().lower())
+    merge(*(args.directories), args.type.strip().lower(), path=args.output_path)
 
 
 main()


### PR DESCRIPTION
I hope that title is self-explanatory:) 

I really miss this functionality in my day-to-day and it seems that in the package everything is ready for it and just parser in the script was not configured.