### PR TITLE
Add comment to the release note 0.8.2.2 (about issue#46)

### DIFF
--- a/docs/src/ReleaseNotes.md
+++ b/docs/src/ReleaseNotes.md
@@ -3,7 +3,7 @@
 #### v0.8.2 March 4, 2024
 TB2J can now read the "tb.dat" file instead of the "hr.dat"+"centers.xyz" files. 
 
-Allow atom symbols+number format (e.g. Fe1, Fe2) in Wannier .win file, and in the --magnetic\_elements option
+(>=0.8.2.2) Allow atom symbols+number format (e.g. Fe1, Fe2) in Wannier .win file, and in the --magnetic\_elements option
 
 #### v0.8.1 Febrary 25, 2024
 Interface with ABACUS for non-collinaer spin calculations is inplemented. 


### PR DESCRIPTION
Hello!

The release note was stating that the bugfix of issue#46 is fixed in the version 0.8.2, however if the user has the version 0.8.2.1 installed, then the bug remains. The added comment specifies minimal version of TB2J with the fixed bug.

P.S. Another suggestion is to mention the issue there as well, but I leave that choice up to you.

Best,
Andrey